### PR TITLE
Better Discord Rich Presence Support

### DIFF
--- a/mods/deathmatch/mtaserver.conf.bak
+++ b/mods/deathmatch/mtaserver.conf.bak
@@ -242,6 +242,7 @@
 	<resource src="dynamic_lighting" startup="1" />
 	<resource src="dynamic_lighting_flash" startup="1" />
 	<resource src="dynamic_lighting_vehicles" startup="1" />
+     <resource src="discord" startup="1" />
     <!--<resource src="snow" startup="1"/>
     <resource src="shader_snow_ground" startup="1"/>
     <resource src="xmas" startup="1"/>-->

--- a/mods/deathmatch/resources/account/s_characters.lua
+++ b/mods/deathmatch/resources/account/s_characters.lua
@@ -518,6 +518,9 @@ function spawnCharacter(characterID, remoteAccountID, theAdmin, targetAccountNam
         if freshSpawn then
             triggerEvent( "social:look", client, client, ":edit" )
         end
+
+        -- update discord
+        triggerClientEvent(client, "discord:updateRPC", client)
     end
 end
 addEventHandler("accounts:characters:spawn", getRootElement(), spawnCharacter)

--- a/mods/deathmatch/resources/discord/c_discord.lua
+++ b/mods/deathmatch/resources/discord/c_discord.lua
@@ -1,0 +1,37 @@
+-- Update function.
+function updateRPC()
+    if isDiscordRichPresenceConnected() then 
+        local name = getPlayerName(localPlayer)
+        
+        local currentPlayers = getElementsByType("player")
+        local maxPlayers = getElementData(root, "server:Slots") or 1024
+
+        if getElementData(localPlayer, "loggedin") == 0 then
+            setDiscordRichPresenceDetails("Logging into OwlGaming...")
+        else
+            setDiscordRichPresenceDetails("Playing as: "..name:gsub("_", " "))
+        end
+
+        setDiscordRichPresenceState("Currently " .. #currentPlayers .. "/" .. maxPlayers  .. " playing!")
+    end
+end
+addEvent("discord:updateRPC", true)
+addEventHandler("discord:updateRPC", root, updateRPC)
+
+function connectRPC(appId)
+    -- reset
+    resetDiscordRichPresenceData()
+
+    -- set discord ApplicationID
+    setDiscordApplicationID(appId)
+
+    -- force an update.
+    updateRPC()
+end
+addEvent("discord:connectRPC", true)
+addEventHandler("discord:connectRPC", root, connectRPC)
+
+-- prevents the rich presence bugging.
+addEventHandler("onClientResourceStop", resourceRoot, function()
+    resetDiscordRichPresenceData()
+end)

--- a/mods/deathmatch/resources/discord/meta.xml
+++ b/mods/deathmatch/resources/discord/meta.xml
@@ -1,0 +1,6 @@
+<meta>
+    <info author="Unitts - OwlGaming" type="script"/>
+
+    <script type="client" src="c_discord.lua" cache="false"/>
+    <script type="server" src="s_discord.lua"/>
+</meta>

--- a/mods/deathmatch/resources/discord/s_discord.lua
+++ b/mods/deathmatch/resources/discord/s_discord.lua
@@ -1,0 +1,20 @@
+-- The below function will handle if the resource is restarted while players are on the server... let's sort out a few things...
+local appKey = get("application_id")
+
+function startUp()
+    for _, player in ipairs(getElementsByType("player")) do 
+       triggerClientEvent(player, "discord:connectRPC", player, appKey)
+    end
+end
+
+-- we add a delay here so that the client resource loads in.
+function delayStartup() 
+    setTimer(startUp, 2000, 1)
+end
+addEventHandler("onResourceStart", root, delayStartup)
+
+-- sends the application key to the player on join.
+function playerJoin()
+    triggerClientEvent(source, "discord:connectRPC", source, appKey)
+end
+addEventHandler("onPlayerJoin", root, playerJoin)

--- a/mods/deathmatch/settings.xml.bak
+++ b/mods/deathmatch/settings.xml.bak
@@ -24,6 +24,9 @@
 	<!-- Imgur Client ID used to get dimensions of skins and item-texture stuff -->
 	<setting name="imgurClient" value="IMGUR_API_KEY" />
 
+	<!-- Discord Application ID for integration -->
+	<setting name="@discord.application_id" value="DISCORD_APP_KEY"/>
+
 	<!-- Scanner -->
 	<setting name="@payday.inactivityscanner_vehicles" value="1" />
 	<setting name="@payday.inactivityscanner_interiors" value="1" />


### PR DESCRIPTION
in MTASA 1.6 we saw the integration of Discord Rich Presence, this is someone that was added after Owl's time and I thought it would be pretty cool to integrate it into the code base as a feature for anyone continuing to use this codebase.

![image](https://github.com/user-attachments/assets/e7a34c12-8562-4edd-ae6e-5ba25fc7ffd5)

So you may be asking how does this work? to use Discord Rich Presence with MTASA you have to create an application for your server,  you're able to do this via this link: https://discord.com/developers/applications 

Once you've created your application you need to copy the Application ID and paste it into the settings.xml value I've created for this, then when you connect it should update the players discord rich presence. 
